### PR TITLE
Update broccoli-asset-rev to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "glob": "^3.2.9",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-ember-data": "0.1.0",
-    "broccoli-asset-rev": "0.0.11"
+    "broccoli-asset-rev": "0.0.15"
   }
 }


### PR DESCRIPTION
I just tried to run the demo ember cli app in this repo and got the following error. Updating `broccoli-asset-rev` to the latest version seems to fix the issue.

``` bash
$ node_modules/.bin/ember server
version: 0.0.37
The `EmberCLIAssetRev` addon must implement the `treeFor` hook.Error: The `EmberCLIAssetRev` addon must implement the `treeFor` hook.
    at EmberApp.<anonymous> (/Users/bmac/code/liquid-fire/node_modules/ember-cli/lib/broccoli/ember-app.js:122:13)
    at Array.map (native)
    at EmberApp.addonTreesFor (/Users/bmac/code/liquid-fire/node_modules/ember-cli/lib/broccoli/ember-app.js:120:40)
    at EmberApp.<anonymous> (/Users/bmac/code/liquid-fire/node_modules/ember-cli/lib/broccoli/ember-app.js:198:25)
    at EmberApp.memoized [as _processedAppTree] (/Users/bmac/code/liquid-fire/node_modules/ember-cli/node_modules/lodash-node/modern/functions/memoize.js:65:28)
...
```
