### PR TITLE
Allow `use=` to specify transition at helper level

### DIFF
--- a/app-addon/helpers/liquid-with.js
+++ b/app-addon/helpers/liquid-with.js
@@ -18,7 +18,7 @@ export default function liquidWithHelper() {
   });
   innerOptions.hash.boundContextBinding = context;
 
-  ['class', 'classNames', 'classNameBindings'].forEach(function(field){
+  ['class', 'classNames', 'classNameBindings', 'use'].forEach(function(field){
     if (options.hash[field]) {
       innerOptions.hash[field] = options.hash[field];
       innerOptions.hashTypes[field] = options.hashTypes[field];

--- a/app-addon/templates/liquid-bind.hbs
+++ b/app-addon/templates/liquid-bind.hbs
@@ -1,4 +1,4 @@
-{{#liquid-with _view.boundContext classNames=_view.classNames classNameBindings=_view.classNameBindings}}
+{{#liquid-with _view.boundContext classNames=_view.classNames classNameBindings=_view.classNameBindings use=_view.use}}
   {{this}}
 {{/liquid-with}}
 

--- a/app-addon/views/liquid-outlet.js
+++ b/app-addon/views/liquid-outlet.js
@@ -41,7 +41,7 @@ export default Ember.ContainerView.extend(Ember._Metamorph, {
 
     // `transitions` comes from dependency injection, see the
     // liquid-fire app initializer.
-    var transition = this.get('transitions').transitionFor(this, oldView, newView);
+    var transition = this.get('transitions').transitionFor(this, oldView, newView, this.get('use'));
 
     if (this._runningTransition) {
       this._runningTransition.interrupt();

--- a/tests/unit/views/liquid-bind-test.js
+++ b/tests/unit/views/liquid-bind-test.js
@@ -86,3 +86,22 @@ test("it should update bound class name", function() {
   });
   equal(view.$('.liquid-child.humor').length, 1, "found bound class");
 });
+
+makeModuleFor("{{liquid-bind}} `use` option", {
+  template: "{{liquid-bind value use='foo'}}",
+  context: {
+    value: 123
+  },
+  setup: function() {
+    var self = this;
+    this.container.register('transition:foo', function(oldView, insertNewView) {
+      self.fooCalled = true;
+      return insertNewView();
+    });
+  }
+});
+
+test("it should pass through the 'use' option to the underlying liquid-outlet", function() {
+  ok(this.fooCalled, "foo transition was used without looking up transition map");
+});
+

--- a/tests/unit/views/liquid-outlet-test.js
+++ b/tests/unit/views/liquid-outlet-test.js
@@ -153,3 +153,22 @@ test("outlet should support static class on liquid children", function() {
   appendView(view);
   equal(view.$('.liquid-child.foo').length, 1, "should have class");
 });
+
+test("outlet should support directly specifying a transition to use", function() {
+  expect(1);
+  container.register('transition:foo', function(oldView, insertNewView) {
+    ok(true, "foo transition was used without looking up transition map");
+    return insertNewView();
+  });
+
+  makeView({
+    template: '{{liquid-outlet use="foo"}}'
+  });
+  run(function() {
+    view.connectOutlet('main', Ember.View.create({
+      template: compile("<p>FIRST</p>")
+    }));
+  });
+  appendView(view);
+});
+

--- a/vendor-addon/liquid-fire/transitions.js
+++ b/vendor-addon/liquid-fire/transitions.js
@@ -18,16 +18,23 @@ Transitions.prototype = {
     return handler;
   },
 
-  transitionFor: function(parentView, oldView, newContent) {
-    var key = this.match(parentView, oldView, newContent),
-        handler;
-
-    if (key && typeof(key.method) === 'function') {
-      handler = key.method;
-    } else if (key) {
-      handler = this.lookup(key.method);
+  transitionFor: function(parentView, oldView, newContent, use) {
+    var handler, args;
+    if (use) {
+      handler = this.lookup(use);
+    } else {
+      var key = this.match(parentView, oldView, newContent);
+      if (key) {
+        args = key.args;
+        if (typeof(key.method) === 'function') {
+          handler = key.method;
+        } else {
+          handler = this.lookup(key.method);
+        }
+      }
     }
-    return new Transition(parentView, oldView, newContent, handler, (key ? key.args : undefined), this);
+
+    return new Transition(parentView, oldView, newContent, handler, args, this);
   },
 
   map: function(handler) {


### PR DESCRIPTION
e.g.

```
{{#liquid-if woot use="crossfade"}}
  I fade in and out of existence without
  having to look up the transition map
{{/liquid-if}}
```

Closes #19
