### PR TITLE
Don’t use browser native Promise

### DIFF
--- a/app-addon/transitions/move-over.js
+++ b/app-addon/transitions/move-over.js
@@ -1,4 +1,4 @@
-import { stop, animate } from "vendor/liquid-fire";
+import { stop, animate, Promise } from "vendor/liquid-fire";
 
 export default function moveOver(oldView, insertNewView, dimension, direction, opts) {
   var property  = 'translate' + dimension.toUpperCase(),

--- a/app/transitions/rotate-below.js
+++ b/app/transitions/rotate-below.js
@@ -1,5 +1,5 @@
 // BEGIN-SNIPPET rotate-below
-import { stop, animate } from "vendor/liquid-fire";
+import { stop, animate, Promise } from "vendor/liquid-fire";
 
 export default function rotateBelow(oldView, insertNewView, opts) {
   var direction = 1;


### PR DESCRIPTION
Because “esnext”: true in jshintrc, jshint wasn’t
reporting undefined `Promise` references.

Opened this in the meantime:
https://github.com/jshint/jshint/issues/1793
