### PR TITLE
Added support for easing with liquid-box.

### DIFF
--- a/app-addon/components/liquid-box.js
+++ b/app-addon/components/liquid-box.js
@@ -4,6 +4,7 @@ import { animate, stop } from "vendor/liquid-fire";
 export default Ember.Component.extend({
   classNames: ['liquid-box'],
   duration: 250,
+  easing: 'slide',
   trackWidth: true,
   trackHeight: true,
   _enabled: false,
@@ -42,7 +43,7 @@ export default Ember.Component.extend({
     stop(this);
     animate(this,
             this.targetDimensions(this.get('contentWidth'), this.get('contentHeight')),
-            { duration: this.get('_enabled') ? this.get('duration') : 0}
+            { duration: this.get('_enabled') ? this.get('duration') : 0, easing: this.get('easing')}
            );
   }
 });

--- a/app/templates/helpers-documentation/liquid-box.hbs
+++ b/app/templates/helpers-documentation/liquid-box.hbs
@@ -15,6 +15,9 @@ change. It accepts these properties:</p>
   changes. Defaults to 250. Set it to 0 if you don't want to
   animate.</dd>
 
+  <dt>easing</dt>
+  <dd>Allows the animation to use easing, see <a href="http://julian.com/research/velocity/#easing">velocity documentation</a> for more information on easing options. Defaults to 'slide'.</dd>
+
   <dt>trackWidth</dt>
   <dd>Set this to false if you want to disable changes to the
   liquid-box's width. Defaults to true.</dd>


### PR DESCRIPTION
Hi,

Using `Ember.run.once(self, 'updateMeasurements');` has definitely helped solve some of the issues I've experience with liquid-box but from time to time it still seems to collapse the elements completely during transition (using fade transitions) or disappear completely (during move-to transitions).

After spending some time trying to solve this bug I feel like the issues around measuring and the run loop are beyond my level of comprehension.

As a workaround it seems like using easing on the liquid box has reduced the frequency of the occurrences of this bug - and it also improves the effect of the animation IMO so I was wondering if you would consider including it in the library - it could be useful for others too?

Thanks again for your efforts, i'm amazed with the sophistication of the animations i'm now able to produce, it's really great!
