### PR TITLE
safeguard jshint against global Promise references

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,8 @@
   "predef": {
     "document": true,
     "window": true,
-    "LiquidFireENV": true
+    "LiquidFireENV": true,
+    "-Promise": true
   },
   "browser" : true,
   "boss" : true,


### PR DESCRIPTION
This will make jshint yell at us if we reference
Promise but forget to import it.
