### PR TITLE
Add `liquid-unless` helper

### DIFF
--- a/app-addon/helpers/liquid-if.js
+++ b/app-addon/helpers/liquid-if.js
@@ -1,11 +1,20 @@
 import Ember from "ember";
 
-export default function(property, options) {
-  var View = options.data.view.container.lookupFactory('view:liquid-if');
-  options.hash.firstTemplate = options.fn;
-  delete options.fn;
-  options.hash.secondTemplate = options.inverse;
-  delete options.inverse;
-  options.hash.showFirstBinding = property;
-  return Ember.Handlebars.helpers.view.call(this, View, options);
+export function factory(invert) {
+  return function(property, options) {
+    var View = options.data.view.container.lookupFactory('view:liquid-if');
+
+    var templates = [options.fn, options.inverse];
+    if (invert) {
+      templates.reverse();
+    }
+    delete options.fn;
+    delete options.inverse;
+
+    options.hash.templates = templates;
+    options.hash.showFirstBinding = property;
+    return Ember.Handlebars.helpers.view.call(this, View, options);
+  };
 }
+
+export default factory(false);

--- a/app-addon/helpers/liquid-unless.js
+++ b/app-addon/helpers/liquid-unless.js
@@ -1,0 +1,2 @@
+import { factory } from "./liquid-if";
+export default factory(true);

--- a/app-addon/views/liquid-if.js
+++ b/app-addon/views/liquid-if.js
@@ -3,7 +3,7 @@ import Ember from "ember";
 
 export default LiquidOutlet.extend({
   liquidUpdate: Ember.on('init', Ember.observer('showFirst', function(){
-    var template = this.get((this.get('showFirst') ? 'first' : 'second') + 'Template');
+    var template = this.get('templates')[this.get('showFirst') ? 0 : 1];
     var view = Ember._MetamorphView.create({
       container: this.container,
       template: template,

--- a/app/templates/helpers-documentation/liquid-if.hbs
+++ b/app/templates/helpers-documentation/liquid-if.hbs
@@ -11,6 +11,9 @@ and <code>false</code> states.</li>
     helpers.
 </ul>
 
+<p><code>\{{#liquid-unless}}</code> is the complement to
+<code>\{{#liquid-if}}</code>.</p>
+
 <h3>Demo</h3>
 
 <p>Here's a bit of a silly example that shows off the flexibility of


### PR DESCRIPTION
It seems only natural that a helper exist to complement `liquid-if`.

Let me know if you think there should be additional documentation. I'm not really sure where to place a test for it, though it's pretty well covered by the test for `liquid-if`.
