### PR TITLE
Prevent test/demo app config from leaking into consuming app.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ module.exports = {
   included: function(app) {
     app.import('vendor/velocity/jquery.velocity.js');
     app.import('vendor/liquid-fire/liquid-fire.css');
+  },
+
+  config: function() {
+    // prevent `config/environment.js` from being used
   }
 };
 


### PR DESCRIPTION
As of Ember CLI 0.0.45 and up, the file located at `config/environment.js` will be used to return the addon's own configuration.  That conflicts with the way this library is using `config/environment.js` (for the testing/demo app).

This simply overrides the default config hook to return nothing.

Closes #74.
