### PR TITLE
Added "scrollThen" that can apply a scroll animation before transitions

### DIFF
--- a/app-addon/transitions/scroll-then.js
+++ b/app-addon/transitions/scroll-then.js
@@ -1,0 +1,31 @@
+import Ember from 'ember';
+
+export default function() {
+  Ember.assert(
+    "You must provide a transition name as the first argument to scrollThen. Example: this.use('scrollThen', 'toLeft')",
+    'string' === typeof arguments[2]
+  );
+
+  var el = document.getElementsByTagName('html'),
+      transitionArgs = Array.prototype.slice.call(arguments, 0, 2),
+      nextTransition = this.lookup(arguments[2]),
+      self = this,
+      options = arguments[3] || {};
+
+  Ember.assert(
+    "The second argument to scrollThen is passed to Velocity's scroll function and must be an object",
+    'object' === typeof options
+  );
+
+  // set scroll options via: this.use('scrollThen', 'ToLeft', {easing: 'spring'})
+  options = Ember.merge({duration: 500, offset: 0}, options);
+
+  // additional args can be passed through after the scroll options object
+  // like so: this.use('scrollThen', 'moveOver', {duration: 100}, 'x', -1);
+  transitionArgs.push.apply(transitionArgs, Array.prototype.slice.call(arguments, 4));
+
+  return window.$.Velocity(el, 'scroll', options).then(function() {
+    nextTransition.apply(self, transitionArgs);
+  });
+}
+


### PR DESCRIPTION
Related to issue #76

Usage:

```
this.transition(
  this.fromRoute('posts'),
  this.use('scrollThen', 'toLeft'),
  this.reverse('scrollThen', 'toRight', {duration: 100})
);
```

This solution works well but the resulting syntax feels like it won't be very DRY and could be difficult for a newcomer to reason about. Would something like the following be better? `first` would operate on the old view and `after` would operate on the new view.

```
this.transition(
  this.fromRoute('posts'),
  this.first('scroll', {duration: 500}).use('toLeft'),
  this.reverse('toRight').after('scroll')
);
```

And perhaps for a `liquid-if` that's used to display a form:

```
this.transition(
  this.withinRoute('post'),
  this.toModel(true),
  this.use('toDown').after('scroll', {toElement: '#my-form'}),
  this.reverse('toUp')
);
```
