### PR TITLE
Send actions from modal components

### DIFF
--- a/app/components/hello-modal.js
+++ b/app/components/hello-modal.js
@@ -5,6 +5,9 @@ export default Ember.Component.extend({
   actions: {
     gotIt: function() {
       this.sendAction('dismiss');
+    },
+    change: function() {
+      this.sendAction('changeSalutation');
     }
   }
 });

--- a/app/router.js
+++ b/app/router.js
@@ -41,7 +41,10 @@ Router.map(function() {
 
     // BEGIN-SNIPPET hello-modal-map
     this.modal('hello-modal', {
-      withParams: ['salutation', 'person']
+      withParams: ['salutation', 'person'],
+      actions: {
+        changeSalutation: "changeSalutation"
+      }
     });
     // END-SNIPPET
 

--- a/app/routes/modal-documentation/index.js
+++ b/app/routes/modal-documentation/index.js
@@ -1,3 +1,12 @@
 import Ember from "ember";
 import ResetScroll from "liquid-fire/mixins/reset-scroll";
-export default Ember.Route.extend(ResetScroll);
+export default Ember.Route.extend(ResetScroll, {
+  actions: {
+    changeSalutation: function() {
+      var controller = this.controllerFor("modal-documentation");
+      var current = controller.get("salutation");
+      var salutation = current === "Guten tag" ? "Hello" : "Guten tag";
+      controller.set("salutation", salutation);
+    }
+  }
+});

--- a/app/templates/components/hello-modal.hbs
+++ b/app/templates/components/hello-modal.hbs
@@ -1,4 +1,5 @@
-{{!- BEGIN-SNIPPET hello-modal -}} 
+{{!- BEGIN-SNIPPET hello-modal -}}
 <div>{{salutation}} {{person}}!</div>
-<button {{action "gotIt"}}>Thanks</button>
+<button {{action "gotIt"}} class="done">Thanks</button>
+<button {{action "change"}} class="change">Change</button>
 {{!- END-SNIPPET -}}

--- a/app/templates/modal-documentation/index.hbs
+++ b/app/templates/modal-documentation/index.hbs
@@ -43,7 +43,7 @@ button. But this is optional.</p>
     {{code-snippet name="hello-modal.js"}}
 
   <li>Call {{#link-to "modal-documentation.modal"}}modal(){{/link-to}}
-  within your router map, at whichever scope you choose:
+  within your router map, at whichever scope you choose and wire up any actions:
 
     {{code-snippet name="hello-modal-map.js"}}
 

--- a/app/templates/modal-documentation/modal.hbs
+++ b/app/templates/modal-documentation/modal.hbs
@@ -41,6 +41,13 @@ re-animates.</p>
   <dt>ariaLabel</dt>
   <dd>Lets you set the aria-label property on the modal dialog box for
     proper accessibility.</dd>
+
+  <dt>actions</dt>
+  <dd>
+    Wire up actions from the modal component's <code>sendAction</code> to your app. For example,
+    <code>actions: {submit: "modalSubmitted"}</code> will trigger the <code>modalSubmitted</code>
+    event on your controller when a <code>submit</code> event is fired in your modal.
+  </dd>
 </dl>
 
 <div class="callout callout-info">We still need an API for customizing

--- a/tests/acceptance/demos-test.js
+++ b/tests/acceptance/demos-test.js
@@ -160,7 +160,13 @@ test('modal demo', function() {
   click('#basic-modal-demo button');
   andThen(function(){
     findWithAssert('.hello-modal');
-    click('.hello-modal button');
+    click('.hello-modal button.change');
+  });
+  andThen(function(){
+    ok(find('.hello-modal').text().match(/Hello/), "Salutation has changed");
+  });
+  andThen(function(){
+    click('.hello-modal button.done');
   });
   andThen(function(){
     equal(find('.hello-modal').length, 0, "dismissed hello-modal");


### PR DESCRIPTION
Adds an `actions` option, for example:

``` javascript
this.modal(‘a-modal’, { 
  withParams: [‘bar’], 
  actions: { submit: “submitModal”} 
})
```
