### PR TITLE
prefer an injection rule

### DIFF
--- a/app-addon/components/liquid-modal.js
+++ b/app-addon/components/liquid-modal.js
@@ -4,9 +4,7 @@ export default Ember.Component.extend({
   classNames: ['liquid-modal'],
   currentContext: Ember.computed.oneWay('owner.modalContexts.lastObject'),
 
-  owner: Ember.computed('container', function(){
-    return this.get('container').lookup('liquid-modals:main');
-  }),
+  owner: null, // set by injection
 
   innerView: Ember.computed('currentContext', function() {
     var self = this,
@@ -70,7 +68,6 @@ export default Ember.Component.extend({
     }
   }
 });
-
 
 function proxyToInnerInstance(self, message) {
   var vi = self.get('innerViewInstance');

--- a/app-addon/initializers/liquid-fire.js
+++ b/app-addon/initializers/liquid-fire.js
@@ -4,7 +4,7 @@ import Ember from "ember";
 export default {
   name: 'liquid-fire',
 
-  initialize: function(container) {
+  initialize: function(container, application) {
     if (!Ember.$.Velocity) {
       Ember.warn("Velocity.js is missing");
     } else {
@@ -16,6 +16,8 @@ export default {
     }
 
     initialize(container, container.lookupFactory('transitions:main'));
+
+    application.inject('component:liquid-modal', 'owner', 'liquid-modals:main');
 
     if (Ember.testing) {
       Ember.Test.registerWaiter(function(){


### PR DESCRIPTION
once `Ember.inject` lands it will be a better solution, but this is likely good for now.

[fixes #103]
