### PR TITLE
Added some padding to the bottom of the documentation

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -16,7 +16,8 @@ $font-size-h4: ceil(($font-size-base * 1));
 
 body {
     background-color: #faf4f1;
-}    
+    padding-bottom: 80px;
+}
 
 .header {
     background-color: $tertiary;
@@ -94,6 +95,7 @@ body {
 .mark-holder {
     text-align: right;
 }
+
 
 @import "demos";
 @import "scenarios";


### PR DESCRIPTION
Added 80px of padding to the bottom of the documentation to give the content some room. 

Before: 
![image](https://cloud.githubusercontent.com/assets/647691/5259182/5b192ac8-79b1-11e4-8825-a4ecc7f3c158.png)

After: 
![image](https://cloud.githubusercontent.com/assets/647691/5259188/69532ce2-79b1-11e4-8b36-fec58771fe5b.png)
