### PR TITLE
Fix nested liquid outlets being visible

### DIFF
--- a/app/components/liquid-child.js
+++ b/app/components/liquid-child.js
@@ -3,11 +3,8 @@ export default Ember.Component.extend({
   classNames: ['liquid-child'],
 
   updateElementVisibility: function() {
-    let visible = this.get('visible');
-    let $container = this.$();
-
-    if ($container && $container.length) {
-      $container.css('visibility', visible ? 'visible' : 'hidden');
+    if (this.element) {
+      this.element.style.visibility = this.get('visible') ? '' : 'hidden';
     }
   }.on('willInsertElement').observes('visible'),
 


### PR DESCRIPTION
If liquid-outlets are nested, sometimes the nested outlets
shine through supposedly hidden outlets.

Basic html example:
```html
<div style="visibility:hidden">
  <div style="visibility:visible">
    I'm visible, even though my parent isn't!
  </div>
</div>
```