### PR TITLE
add `scrollWhile` transition

### DIFF
--- a/app/transitions/scroll-while.js
+++ b/app/transitions/scroll-while.js
@@ -26,4 +26,4 @@ export default function(nextTransitionName, options, ...rest) {
     window.$.Velocity(el, 'scroll', options),
     nextTransition.apply(this, rest)
   ]);
-};
+}

--- a/app/transitions/scroll-while.js
+++ b/app/transitions/scroll-while.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+import { Promise } from 'liquid-fire';
+
+export default function(nextTransitionName, options, ...rest) {
+  Ember.assert(
+    "You must provide a transition name as the first argument to scrollWhile. Example: this.use('scrollWhile', 'toLeft')",
+    'string' === typeof nextTransitionName
+  );
+
+  var el = document.getElementsByTagName('html');
+  var nextTransition = this.lookup(nextTransitionName);
+  if (!options) { options = {}; }
+
+  Ember.assert(
+    "The second argument to scrollWhile is passed to Velocity's scroll function and must be an object",
+    'object' === typeof options
+  );
+
+  // set scroll options via: this.use('scrollWhile', 'ToLeft', {easing: 'spring'})
+  options = Ember.merge({duration: 500, offset: 0}, options);
+
+  // additional args can be passed through after the scroll options object
+  // like so: this.use('scrollWhile', 'moveOver', {duration: 100}, 'x', -1);
+
+  return Promise.all([
+    window.$.Velocity(el, 'scroll', options),
+    nextTransition.apply(this, rest)
+  ]);
+};


### PR DESCRIPTION
I needed a way to scroll the page in parallel with another transition, so I copied the `scrollThen` transition and changed it to resolve the promise after both the scroll and `nextTransition` complete.

Although useful, it does seem a little awkward to use `scrollThen` and `scrollWhile`. Any ideas/plans for improving the DSL to make it easier to compose serial and parallel transitions?
