### PR TITLE
added onDestroy jquery data removal for OutletView to prevent massive DOM leaks when multiple transitions are present

### DIFF
--- a/addon/ember-internals.js
+++ b/addon/ember-internals.js
@@ -185,11 +185,14 @@ function sameRouteState(a, b) {
 // This lets us invoke an outlet with an explicitly passed outlet
 // state, rather than inheriting it implicitly from its context.
 export var StaticOutlet = Ember.OutletView.superclass.extend({
-  tagName: '',
+  //tagName: '',
 
   setStaticState: Ember.on('init', Ember.observer('staticState', function() {
     this.setOutletState(this.get('staticState'));
-  }))
+  })),
+  onWillDestroy: Ember.on('willDestroyElement', function(){
+    this.$().removeData();
+  })
 });
 
 // Finds the route name from a route state so we can apply our

--- a/addon/running-transition.js
+++ b/addon/running-transition.js
@@ -34,6 +34,11 @@ export default class RunningTransition {
 
   _invokeAnimation() {
     return this.animation.run(this.animationContext).then(() => {
+      this.animationContext.oldElement = null;
+      this.animationContext.newElement = null;
+      this.animationContext.older.forEach((entry) => {
+          entry.element = null;
+      });
       return this.interrupted;
     });
   }

--- a/app/components/liquid-child.js
+++ b/app/components/liquid-child.js
@@ -13,5 +13,8 @@ export default Ember.Component.extend({
 
   tellContainerWeRendered: Ember.on('didInsertElement', function(){
     this.sendAction('didRender', this);
+  }),
+  onWillDestroy: Ember.on('willDestroyElement', function(){
+    this.$().removeData();
   })
 });

--- a/app/components/liquid-container.js
+++ b/app/components/liquid-container.js
@@ -86,6 +86,7 @@ export default Ember.Component.extend(Growable, {
         goStatic(versions[i]);
       }
       this.unlockSize();
+      $(this.$()).removeData('velocity');
     }
   }
 });

--- a/app/components/liquid-versions.js
+++ b/app/components/liquid-versions.js
@@ -90,6 +90,13 @@ export default Ember.Component.extend({
   },
 
   finalizeVersions: function(versions) {
+    if(versions.length>1){
+      for(var i=1;i<versions.length; i++){
+        if(versions[i].view) {
+          Ember.$.removeData(versions[i].view.element, 'velocity');
+        }
+      }
+    }
     versions.replace(1, versions.length - 1);
   },
 

--- a/app/components/liquid-versions.js
+++ b/app/components/liquid-versions.js
@@ -92,7 +92,7 @@ export default Ember.Component.extend({
   finalizeVersions: function(versions) {
     if(versions.length>1){
       for(var i=1;i<versions.length; i++){
-        if(versions[i].view) {
+        if(versions[i].view && versions[i].view.element) {
           Ember.$.removeData(versions[i].view.element, 'velocity');
         }
       }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "4.1.0",
     "ember-cli-htmlbars": "^0.7.4",
     "ember-cli-version-checker": "^1.0.2",
-    "velocity-animate": ">= 0.11.8"
+    "velocity-animate": "git+https://github.com/nonmanifold/velocity"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",


### PR DESCRIPTION
detach velocity data from versions upon destroy
remove data on liquid-child destroy
cleanup to prevent leaks