### PR TITLE
Add configurable directions for liquid-spacer

### DIFF
--- a/addon/components/liquid-spacer.js
+++ b/addon/components/liquid-spacer.js
@@ -10,9 +10,14 @@ export default Ember.Component.extend(Growable, {
   didInsertElement: function() {
     var child = this.$('> div');
     var measurements = this.myMeasurements(measure(child));
-    this.$().css('overflow', 'hidden')
-      .outerWidth(measurements.width)
-      .outerHeight(measurements.height);
+    var elt = this.$();
+    elt.css('overflow', 'hidden');
+    if (this.get('growWidth')) {
+      elt.outerWidth(measurements.width);
+    }
+    if (this.get('growHeight')) {
+      elt.outerHeight(measurements.height);
+    }
   },
 
   sizeChange: Ember.observer('measurements', function() {

--- a/addon/growable.js
+++ b/addon/growable.js
@@ -6,15 +6,24 @@ export default Ember.Mixin.create({
   growDuration: 250,
   growPixelsPerSecond: 200,
   growEasing: 'slide',
+  growWidth: true,
+  growHeight: true,
 
   transitionMap: Ember.inject.service('liquid-fire-transitions'),
 
   animateGrowth: function(elt, have, want) {
     this.get('transitionMap').incrementRunningTransitions();
-    return Promise.all([
-      this._adaptDimension(elt, 'width', have, want),
-      this._adaptDimension(elt, 'height', have, want)
-    ]).then(()=>{
+    var adaptations = [];
+
+    if (this.get('growWidth')) {
+      adaptations.push(this._adaptDimension(elt, 'width', have, want));
+    }
+
+    if (this.get('growHeight')) {
+      adaptations.push(this._adaptDimension(elt, 'height', have, want));
+    }
+
+    return Promise.all(adaptations).then(()=>{
       this.get('transitionMap').decrementRunningTransitions();
     });
   },

--- a/tests/dummy/app/templates/helpers-documentation/liquid-spacer.hbs
+++ b/tests/dummy/app/templates/helpers-documentation/liquid-spacer.hbs
@@ -26,6 +26,14 @@ and shrinking a container, whenever the stuff inside changes.</p>
   function</a> to use when growing the container height and
   width. Defaults to <code>'slide'</code>.</dd>
 
+  <dt>growWidth, growHeight</dt>
+  <dd>
+    Boolean options (defaulting to <code>true</code>) to control
+    whether to grow horizontally and vertically. Useful for
+    fluid-width or fluid-height content which will grow in height or
+    width.
+  </dd>
+
   <dt>enabled</dt>
   <dd>Whether to animate height and width changes. Defaults to <code>true</code>.</dd>
 

--- a/tests/integration/helpers/liquid-spacer-test.js
+++ b/tests/integration/helpers/liquid-spacer-test.js
@@ -81,6 +81,35 @@ test('it should animate', function(assert) {
   });
 });
 
+test('it should not set width style if growWidth is false', function(assert) {
+  assert.expect(2);
+
+  this.render(`
+               {{#liquid-spacer id="my-spacer" growWidth=false}}
+                 Hi.
+               {{/liquid-spacer}}
+              `);
+
+  var style = this.$('#my-spacer').get(0).style;
+
+  assert.equal(style.width, '', 'width style is unset');
+  assert.ok(/^\d+px$/.test(style.height), 'height style is set to ' + style.height);
+});
+
+test('it should not set height style if growHeight is false', function(assert) {
+  assert.expect(2);
+
+  this.render(`
+               {{#liquid-spacer id="my-spacer" growHeight=false}}
+                 Hi.
+               {{/liquid-spacer}}
+              `);
+
+  var style = this.$('#my-spacer').get(0).style;
+
+  assert.equal(style.height, '', 'height style is unset');
+  assert.ok(/^\d+px$/.test(style.width), 'width style is set to ' + style.width);
+});
 
 
 var shortMessage = "Hi.";


### PR DESCRIPTION
Adds `growWidth` and `growHeight` boolean attributes to the Growable mixin (and therefore to liquid-spacer). These default to `true` to maintain existing behaviour.

Setting either to `false` will prevent liquid-spacer from animating resizes in that direction. This is useful when you have a responsive width element which you want to animate height transitions.

Fixes #392