### PR TITLE
Call `this._super` in `init` of `TransitionMap`.

### DIFF
--- a/addon/transition-map.js
+++ b/addon/transition-map.js
@@ -8,6 +8,8 @@ import getOwner from 'ember-getowner-polyfill';
 
 var TransitionMap = Ember.Service.extend({
   init: function() {
+    this._super(...arguments);
+    
     this.activeCount = 0;
     this.constraints = new Constraints();
     this.map(internalRules);


### PR DESCRIPTION
We should always call `this._super` when implementing `init` or `willDestroy` on core framework classes.