### PR TITLE
Import Stream from `ember-htmlbars/streams/stream` on Ember canary

### DIFF
--- a/addon/ember-internals.js
+++ b/addon/ember-internals.js
@@ -8,7 +8,7 @@ var emberRequire = Ember.__loader.require;
 var internal = emberRequire('htmlbars-runtime').internal;
 var registerKeyword = emberRequire('ember-htmlbars/keywords').registerKeyword;
 var legacyViewKeyword = emberRequire('ember-htmlbars/keywords/view').default;
-var _Stream = emberRequire('ember-metal/streams/stream');
+var _Stream = Ember.__loader.registry['ember-metal/streams/stream'] ? emberRequire('ember-metal/streams/stream') : emberRequire('ember-htmlbars/streams/stream');
 var BasicStream = _Stream.default;
 var Stream = _Stream.Stream;
 
@@ -26,7 +26,7 @@ export function containingElement(view) {
 
 // This is Ember's {{#if}} predicate semantics (where empty lists
 // count as false, etc).
-export var shouldDisplay = emberRequire('ember-views/streams/should_display').default;
+export var shouldDisplay = Ember.__loader.registry['ember-metal/streams/stream'] ? emberRequire('ember-views/streams/should_display').default : emberRequire('ember-htmlbars/streams/should_display').default;
 
 // Finds the route name from a route state so we can apply our
 // matching rules to it.


### PR DESCRIPTION
As of v2.7, Streams are moved to `ember-htmlbars`, we need to check if `ember-metal/streams/stream` exists.