### PR TITLE
Consider liquid-fire non-idle when a liquid-sync is still pending

### DIFF
--- a/addon/mixins/pausable.js
+++ b/addon/mixins/pausable.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 
 export default Ember.Mixin.create({
+  _transitionMap: Ember.inject.service('liquid-fire-transitions'),
+
   _initializeLiquidFirePauseable: Ember.on('init', function() {
     this._lfDefer = [];
   }),
@@ -8,6 +10,9 @@ export default Ember.Mixin.create({
     const context = this.nearestWithProperty('_isLiquidChild');
     if (context) {
       let defer = new Ember.RSVP.defer();
+      let tmap = this.get('_transitionMap');
+      tmap.incrementRunningTransitions();
+      defer.promise.finally(() => tmap.decrementRunningTransitions());
       this._lfDefer.push(defer);
       context._waitForMe(defer.promise);
     }

--- a/app/components/liquid-child.js
+++ b/app/components/liquid-child.js
@@ -13,8 +13,10 @@ export default Ember.Component.extend({
       $container.css('visibility','hidden');
     }
     this._waitForAll().then(() => {
-      this._waitingFor = null;
-      this.sendAction('liquidChildDidRender', this);
+      if (!this.isDestroying) {
+        this._waitingFor = null;
+        this.sendAction('liquidChildDidRender', this);
+      }
     });
   },
 

--- a/tests/integration/helpers/liquid-sync-test.js
+++ b/tests/integration/helpers/liquid-sync-test.js
@@ -45,16 +45,14 @@ test('it causes the transition to wait', function(assert) {
 
   this.set('activated', true);
 
+  assert.equal(animationStarted, false, "No animation yet");
+  assert.equal(this.$('.off').length, 1, "Found Off");
+  assert.equal(this.$('.sample').length, 1, "Found sample");
+
+  Ember.run(() => sample.sendAction('ready'));
+
+  assert.equal(animationStarted, true, "Animation started");
   return tmap.waitUntilIdle().then(() => {
-    assert.equal(animationStarted, false, "No animation yet");
-    assert.equal(this.$('.off').length, 1, "Found Off");
-    assert.equal(this.$('.sample').length, 1, "Found sample");
-
-    Ember.run(() => sample.sendAction('ready'));
-
-    assert.equal(animationStarted, true, "Animation started");
-    return tmap.waitUntilIdle();
-  }).then(() => {
     assert.equal(this.$('.sample').length, 1, "Found sample");
     assert.equal(this.$('.off').length, 0, "Off is gone");
   });
@@ -80,17 +78,33 @@ test('transition moves on if component is destroyed', function(assert) {
 
   this.set('activated', true);
 
+  assert.equal(animationStarted, false, "No animation yet");
+  assert.equal(this.$('.off').length, 1, "Found Off");
+  assert.equal(this.$('.sample').length, 1, "Found sample");
+
+  this.set('innerThing', true);
+
+  assert.equal(animationStarted, true, "Animation started");
   return tmap.waitUntilIdle().then(() => {
-    assert.equal(animationStarted, false, "No animation yet");
-    assert.equal(this.$('.off').length, 1, "Found Off");
-    assert.equal(this.$('.sample').length, 1, "Found sample");
-
-    this.set('innerThing', true);
-
-    assert.equal(animationStarted, true, "Animation started");
-    return tmap.waitUntilIdle();
-  }).then(() => {
     assert.equal(this.$('.alt').length, 1, "Found alt");
     assert.equal(this.$('.off').length, 0, "Off is gone");
   });
+});
+
+test('it considers liquid-fire non-idle when waiting for liquid-sync to resolve', function(assert) {
+  this.render(hbs`
+    {{#liquid-if activated use="spy"}}
+      {{#liquid-sync as |sync|}}
+        {{x-sample ready=sync}}
+      {{/liquid-sync}}
+    {{else}}
+      <div class="off">Off</div>
+    {{/liquid-if}}
+  `);
+
+
+  this.set('activated', true);
+
+  assert.equal(animationStarted, false, "No animation yet");
+  assert.ok(tmap.runningTransitions() > 0, "Isn't idle");
 });


### PR DESCRIPTION
During the time that we are blocked on a liquid-sync, liquid-fire doesn't have any running transitions. This can lead to confusing test failures, since you will try to wait for animations to finish when none have started yet, and your test will progress too soon.

This PR increments the running transitions count whenever we are blocked on a liquid-sync, which closes the gap and ensures you will really wait until an entire transition is completed.

I also made a related change that prevents confusing exceptions when a liquid-child is destroyed before it can notify its parent that it has rendereed.

Bug solved while mob programming with @lkhaas, @ynx, et al.