### PR TITLE
Upgrade htmlbars version to avoid deprecation warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "broccoli-funnel": "^1.0.1",
     "broccoli-merge-trees": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-version-checker": "^1.0.2",
     "ember-getowner-polyfill": "^1.0.0",
     "match-media": "^0.2.0",


### PR DESCRIPTION
In latest ember-cli versions liquid-fire is causing deprecation warnings due to dependency on an older htmlbars.

The warning looks like:
```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` ember-cli-htmlbars
```