### PR TITLE
Squash deprecation warning from latest Ember version

### DIFF
--- a/addon/components/liquid-child.js
+++ b/addon/components/liquid-child.js
@@ -3,7 +3,7 @@ export default Ember.Component.extend({
   classNames: ['liquid-child'],
 
   init() {
-    this._super();
+    this._super.init && this._super.init.apply(this, arguments);
     this._waitingFor = [];
   },
 


### PR DESCRIPTION
Call super from init as Ember recommends.