### PR TITLE
Use unrounded element dimensions

### DIFF
--- a/addon/components/liquid-measured.js
+++ b/addon/components/liquid-measured.js
@@ -66,12 +66,12 @@ export function measure($elt) {
   if ($elt[0].offsetWidth === 0) {
       width = 0;
   } else {
-    width = $elt.outerWidth();
+    width = $elt.getBoundingClientRect().width;
   }
   if ($elt[0].offsetHeight === 0) {
     height = 0;
   } else {
-    height = $elt.outerHeight();
+    width = $elt.getBoundingClientRect().height;
   }
 
   return {

--- a/addon/components/liquid-measured.js
+++ b/addon/components/liquid-measured.js
@@ -66,12 +66,12 @@ export function measure($elt) {
   if ($elt[0].offsetWidth === 0) {
       width = 0;
   } else {
-    width = $elt.getBoundingClientRect().width;
+    width = $elt[0].getBoundingClientRect().width;
   }
   if ($elt[0].offsetHeight === 0) {
     height = 0;
   } else {
-    width = $elt.getBoundingClientRect().height;
+    width = $elt[0].getBoundingClientRect().height;
   }
 
   return {


### PR DESCRIPTION
jQuery's outerWidth() and outerHeight() methods round an element's dimensions. Since the measure function is used for setting width and height on animated elements, it might happen that an element's size is set to be smaller than it's actual size and information get missing.

getBoundingClientRect() returns unrounded values as used by Browsers instead and solves that issue.

The following is an example for broken animation due to rounded dimensions:

![broken-animation-example 2](https://cloud.githubusercontent.com/assets/328382/17248234/770dcf16-5599-11e6-93f9-49aae62d58f3.gif)

The element's width is reported to be 77.42px by the browser, but is set to 77px during animation, leading to the currency symbol being hidden.