### PR TITLE
update ember-cli-htmlbars-inline-precompile to remove warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-deploy": "0.6.4",
     "ember-cli-deploy-build": "0.1.1",
     "ember-cli-deploy-git": "1.0.0",
-    "ember-cli-htmlbars-inline-precompile": "0.3.1",
+    "ember-cli-htmlbars-inline-precompile": "0.3.5",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-sass": "^5.2.1",


### PR DESCRIPTION
Context:

 * https://embercommunity.slack.com/archives/-ember-cli/p1470864929001722
 * https://github.com/babel/broccoli-babel-transpiler/pull/89

Running the dummy app currently displays many warnings:

**before:**

<img width="660" alt="screen shot 2016-08-12 at 14 36 28" src="https://cloud.githubusercontent.com/assets/2526/17624028/d4abd8b4-609a-11e6-9b9d-cd58ced46607.png">

**after:**

<img width="599" alt="screen shot 2016-08-12 at 14 40 40" src="https://cloud.githubusercontent.com/assets/2526/17624036/d93516a2-609a-11e6-8307-06ec6fefa21b.png">
