### PR TITLE
Fix memory leak

### DIFF
--- a/addon/components/liquid-measured.js
+++ b/addon/components/liquid-measured.js
@@ -4,6 +4,12 @@ import layout from "liquid-fire/templates/components/liquid-measured";
 
 export default Ember.Component.extend({
   layout,
+
+  init() {
+    this._super(...arguments);
+    this._destroyOnUnload = this._destroyOnUnload.bind(this);
+  },
+
   didInsertElement: function() {
     var self = this;
 
@@ -23,13 +29,14 @@ export default Ember.Component.extend({
     });
     this.$().bind('webkitTransitionEnd', function() { self.didMutate(); });
     // Chrome Memory Leak: https://bugs.webkit.org/show_bug.cgi?id=93661
-    window.addEventListener('unload', function(){ self.willDestroyElement(); });
+    window.addEventListener('unload', this._destroyOnUnload);
   },
 
   willDestroyElement: function() {
     if (this.observer) {
       this.observer.disconnect();
     }
+    window.removeEventListener('unload', this._destroyOnUnload);
   },
 
   transitionMap: Ember.inject.service('liquid-fire-transitions'),
@@ -51,8 +58,11 @@ export default Ember.Component.extend({
     var elt = this.$();
     if (!elt || !elt[0]) { return; }
     this.set('measurements', measure(elt));
-  }
+  },
 
+  _destroyOnUnload() {
+    this.willDestroyElement();
+  }
 });
 
 export function measure($elt) {


### PR DESCRIPTION
I've found a memory leak in the test suite of or app that was becoming a real issue.

The `liquid-measured` components adds an `unload` event that is never removed when the component it's removed. After a couple tests that render this component the `document.body` ends up in this state:

<img width="1151" alt="screen shot 0028-08-22 at 17 27 41" src="https://cloud.githubusercontent.com/assets/265339/17862700/489f8f5e-688e-11e6-8d5a-725e1945647a.png">

Each one of those `unload` events holds a reference to the component and components hold references to many things.

After this patch the same test suite leaves the body without any `unload` event:

<img width="893" alt="screen shot 0028-08-22 at 17 30 58" src="https://cloud.githubusercontent.com/assets/265339/17862736/726287f6-688e-11e6-9f09-24376b04e553.png">

I don't know if this might be related with #442, but it worth checking.