### PR TITLE
Fix issues with glimmer2 branch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,8 @@ module.exports = {
 
   treeForAddon: function() {
     var tree = this._super.treeForAddon.apply(this, arguments);
-    let emberVersion = this.versionChecker.for('ember', 'bower');
-    if (!emberVersion.lt('2.9.0-glimmer2')) {
+    var emberVersion = this.versionChecker.for('ember', 'bower');
+    if (!emberVersion.lt('2.9.0-alpha.1')) {
       return this._withVersionSpecific(tree, '2.9');
     } else if (!emberVersion.lt('1.13.0')) {
       return this._withVersionSpecific(tree, '1.13');
@@ -32,8 +32,9 @@ module.exports = {
     }
   },
 
-  _withVersionSpecific(tree, version) {
-    return mergeTrees([tree, new Funnel('version-specific-' + version, { destDir: 'modules/liquid-fire/ember-internals/version-specific' })]);
+  _withVersionSpecific: function(tree, version) {
+    var versionSpecificPath = path.join(this.root, 'version-specific-' + version);
+    return mergeTrees([tree, new Funnel(versionSpecificPath, { destDir: 'modules/liquid-fire/ember-internals/version-specific' })]);
   },
 
   treeForVendor: function(tree){

--- a/version-specific-2.9/index.js
+++ b/version-specific-2.9/index.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
-let getViewBounds;
 
-export function initialize() {
-  let emberRequire = Ember.__loader.require;
-  getViewBounds = emberRequire('ember-views/system/utils').getViewBounds;
-}
+const { getViewBounds } = Ember.ViewUtils;
+
+export function initialize() { }
 
 export function containingElement(view) {
   return getViewBounds(view).parentElement;


### PR DESCRIPTION
* Avoid using `let` in Node-land (grrrr).
* Fix issue when `liquid-fire` is not the current working directory
  while building (needed to `path.join` the addon's root before
  funneling).
* Use `Ember.ViewUtils.getViewBounds` instead of `Ember.__loader.require`.