### PR TITLE
Load Velocity.js as an AMD module in versions of Ember CLI that support it

### DIFF
--- a/addon/animate.js
+++ b/addon/animate.js
@@ -1,7 +1,7 @@
+/* jshint newcap: false */
 import Promise from "./promise";
 import Ember from "ember";
-
-var Velocity = Ember.$.Velocity;
+import Velocity from "velocity";
 
 // Make sure Velocity always has promise support by injecting our own
 // RSVP-based implementation if it doesn't already have one.
@@ -64,7 +64,7 @@ export function animate(elt, props, opts, label) {
 
 export function stop(elt) {
   if (elt) {
-    elt.velocity('stop', true);
+    Velocity(elt[0], 'stop', true);
   }
 }
 

--- a/addon/growable.js
+++ b/addon/growable.js
@@ -1,5 +1,7 @@
+/* jshint newcap: false */
 import Ember from "ember";
 import Promise from "liquid-fire/promise";
+import Velocity from "velocity";
 var capitalize = Ember.String.capitalize;
 
 export default Ember.Mixin.create({
@@ -37,7 +39,7 @@ export default Ember.Mixin.create({
       want[dimension],
       have[dimension],
     ];
-    return Ember.$.Velocity(elt[0], target, {
+    return Velocity(elt[0], target, {
       duration: this._durationFor(have[dimension], want[dimension]),
       queue: false,
       easing: this.get('growEasing') || this.constructor.prototype.growEasing

--- a/addon/velocity-ext.js
+++ b/addon/velocity-ext.js
@@ -4,8 +4,8 @@
   to Velocity as PR #485.
 */
 
-import Ember from "ember";
-var VCSS = Ember.$.Velocity.CSS;
+import Velocity from "velocity";
+var VCSS = Velocity.CSS;
 
 function augmentDimension(name, element) {
   var sides = name === 'width' ? ['Left', 'Right' ] : ['Top', 'Bottom'];

--- a/index.js
+++ b/index.js
@@ -80,7 +80,17 @@ module.exports = {
     }
 
     if (!process.env.EMBER_CLI_FASTBOOT) {
-      app.import('vendor/velocity/velocity.js');
+      let haveShimAMDSupport = 'amdModuleNames' in app;
+      if (haveShimAMDSupport) {
+        app.import('vendor/velocity/velocity.js', {
+          using: [{
+            transformation: 'amd', as: 'velocity'
+          }]
+        });
+      } else {
+        app.import('vendor/velocity/velocity.js');
+        app.import('vendor/shims/velocity.js');
+      }
       app.import('vendor/match-media/matchMedia.js');
     }
 

--- a/vendor/shims/velocity.js
+++ b/vendor/shims/velocity.js
@@ -1,0 +1,10 @@
+(function() {
+  function vendorModule() {
+    'use strict';
+    // Velocity tries to register on jQuery first, if it's not present, then it registers itself globally
+    var Velocity = self.Velocity || self.Ember.$.Velocity;
+    return { 'default': Velocity };
+  }
+
+  define('velocity', [], vendorModule);
+})();


### PR DESCRIPTION
I ran across an issue using Liquid Fire with a client app that tries to avoid polluting the global namespace with jQuery & Ember.

This PR uses the newly added AMD shim support in Ember CLI to load Velocity.js as an AMD module. It feature detects whether Ember CLI supports AMD shimming and will fallback to using a vendor module shim in the case that it doesn't. This allows Liquid Fire to consistently use Velocity via the module system.