### PR TITLE
added growthDelay and shrinkDelay

### DIFF
--- a/addon/growable.js
+++ b/addon/growable.js
@@ -8,6 +8,8 @@ export default Ember.Mixin.create({
   growDuration: 250,
   growPixelsPerSecond: 200,
   growEasing: 'slide',
+  shrinkDelay: 0,
+  growDelay: 0,
   growWidth: true,
   growHeight: true,
 
@@ -40,10 +42,19 @@ export default Ember.Mixin.create({
       have[dimension],
     ];
     return Velocity(elt[0], target, {
+      delay: this._delayFor(have[dimension], want[dimension]),
       duration: this._durationFor(have[dimension], want[dimension]),
       queue: false,
       easing: this.get('growEasing') || this.constructor.prototype.growEasing
     });
+  },
+
+  _delayFor: function(before, after) {
+    if (before > after) {
+      return this.get('shrinkDelay') || this.constructor.prototype.shrinkDelay;
+    }
+
+    return this.get('growDelay') || this.constructor.prototype.growDelay;
   },
 
   _durationFor: function(before, after) {

--- a/addon/templates/components/liquid-bind.hbs
+++ b/addon/templates/components/liquid-bind.hbs
@@ -17,6 +17,8 @@
       growDuration=growDuration
       growPixelsPerSecond=growPixelsPerSecond
       growEasing=growEasing
+      shrinkDelay=shrinkDelay
+      growDelay=growDelay
       enableGrowth=enableGrowth
       as |container| ~}}
     {{~#liquid-versions value=value notify=container use=use rules=rules

--- a/addon/templates/components/liquid-if.hbs
+++ b/addon/templates/components/liquid-if.hbs
@@ -24,6 +24,8 @@
       growDuration=growDuration
       growPixelsPerSecond=growPixelsPerSecond
       growEasing=growEasing
+      shrinkDelay=shrinkDelay
+      growDelay=growDelay
       enableGrowth=enableGrowth
       as |container|}}
     {{#liquid-versions value=(if inverted (if predicate false true) (if predicate true false)) notify=container matchContext=(hash helperName=helperName)

--- a/addon/templates/components/liquid-outlet.hbs
+++ b/addon/templates/components/liquid-outlet.hbs
@@ -10,6 +10,8 @@
         growDuration=growDuration
         growPixelsPerSecond=growPixelsPerSecond
         growEasing=growEasing
+        shrinkDelay=shrinkDelay
+        growDelay=growDelay
         enableGrowth=enableGrowth
         as |version| ~}}
         {{#-with-dynamic-vars outletState=version ~}}

--- a/tests/dummy/app/templates/helpers-documentation/index.hbs
+++ b/tests/dummy/app/templates/helpers-documentation/index.hbs
@@ -96,6 +96,14 @@ options:</p>
   function</a> to use when growing the container height and
   width. Defaults to <code>'slide'</code>.</dd>
 
+  <dt>shrinkDelay</dt>
+  <dd>A delay applied before the container shrinks in width or height.
+  Defaults to <code>0</code>.</dd>
+
+  <dt>growDelay</dt>
+  <dd>A delay applied before the container grows in width or height.
+  Defaults to <code>0</code>.</dd>
+
   <dt>enableGrowth</dt>
   <dd>Whether the container should animate its own height and width
   changes. Defaults to <code>true</code>.</dd>


### PR DESCRIPTION
Allows the following: 
1. Wait for a transition to finish before shrinking.
2. Don't grow/shrink early if a delay has been set on a transition.