### PR TITLE
removed polyfills from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-version-checker": "^1.1.6",
-    "ember-getowner-polyfill": "^1.1.1",
-    "ember-hash-helper-polyfill": "^0.1.2",
     "match-media": "^0.2.0",
     "velocity-animate": ">= 0.11.8"
   },


### PR DESCRIPTION
`getOwner` and the hash helper polyfill are now included in Ember 2.3 and up