### PR TITLE
Fix broken FastBoot build, add more FastBoot tests

### DIFF
--- a/fastboot-tests/fixtures/fastboot/app/router.js
+++ b/fastboot-tests/fixtures/fastboot/app/router.js
@@ -7,6 +7,8 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('liquid-bind');
+  this.route('liquid-if');
 });
 
 export default Router;

--- a/fastboot-tests/fixtures/fastboot/app/templates/application.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/application.hbs
@@ -1,0 +1,1 @@
+{{liquid-outlet}}

--- a/fastboot-tests/fixtures/fastboot/app/templates/liquid-bind.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/liquid-bind.hbs
@@ -1,0 +1,5 @@
+<div id="liquid-bind">
+  {{#liquid-bind "liquid-bind" as |value|}}
+    {{value}}
+  {{/liquid-bind}}
+</div>

--- a/fastboot-tests/fixtures/fastboot/app/templates/liquid-if.hbs
+++ b/fastboot-tests/fixtures/fastboot/app/templates/liquid-if.hbs
@@ -1,0 +1,7 @@
+<div id="liquid-if">
+  {{#liquid-if true}}
+    true
+  {{else}}
+    false
+  {{/liquid-if}}
+</div>

--- a/fastboot-tests/liquid-bind-test.js
+++ b/fastboot-tests/liquid-bind-test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const expect = require('chai').expect;
+const setupTest = require('ember-fastboot-addon-tests').setupTest;
+
+describe('liquidBind', function() {
+  setupTest('fastboot'/*, options */);
+
+  it('renders', function() {
+    return this.visit('/liquid-bind')
+      .then(function(res) {
+        let $ = res.jQuery;
+        let response = res.response;
+
+        expect(response.statusCode).to.equal(200);
+        expect($('#liquid-bind').text().trim()).to.equal('liquid-bind');
+      });
+  });
+
+});

--- a/fastboot-tests/liquid-if-test.js
+++ b/fastboot-tests/liquid-if-test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const expect = require('chai').expect;
+const setupTest = require('ember-fastboot-addon-tests').setupTest;
+
+describe('liquidIf', function() {
+  setupTest('fastboot'/*, options */);
+
+  it('renders', function() {
+    return this.visit('/liquid-if')
+      .then(function(res) {
+        let $ = res.jQuery;
+        let response = res.response;
+
+        expect(response.statusCode).to.equal(200);
+        expect($('#liquid-if').text().trim()).to.equal('true');
+      });
+  });
+
+});

--- a/index.js
+++ b/index.js
@@ -107,27 +107,14 @@ module.exports = {
   },
 
   included: function(){
-    if (this._hasShimAMDSupport()) {
-      // if this ember-cli is new enough to do amd imports
-      // automatically, use that
-      this.import('vendor/velocity/velocity.js', {
-        using: [{
-          transformation: 'amd', as: 'velocity'
-        }]
-      });
-    } else {
-      // otherwise apply our own amd shim
-      this.import('vendor/velocity/velocity.js');
-      this.import('vendor/shims/velocity.js');
-    }
+    // We cannot use ember-cli to import velocity as an AMD module here, because we always need the shim in FastBoot
+    // to not break any module imports (as velocity/velocity.js has a FastBoot guard, so FastBoot does not see any
+    // module inside
+    this.import('vendor/velocity/velocity.js');
+    this.import('vendor/shims/velocity.js');
 
     this.import('vendor/match-media/matchMedia.js');
     this.import('vendor/liquid-fire.css');
-  },
-
-  _hasShimAMDSupport: function(){
-    var app = this._findHost();
-    return 'amdModuleNames' in app;
   }
 };
 


### PR DESCRIPTION
Fixes #569

As stated in the above issue, the problem with the latest FastBoot 1.0 related changes in #568 was that the `velocity.js` module was not visible within FastBoot when directly imported as an AMD module, because of the newly introduced FastBoot guard added to it. This broke imports like https://github.com/ember-animation/liquid-fire/blob/master/addon/growable.js#L4.

I chose here to not use the AMD import feature of ember-cli, so the shim is always imported, which makes FastBoot import an empty dummy module, which is how it was before the changes.

The alternative would be to still use the AMD import, but then we would have to use the newly introduced `updateFastBootManifest` hook in `ember-cli-fastboot` as @kratiahuja suggested to include the shim into FastBoot's manifest, so we have the dummy module added to the FastBoot sandbox this way. This would require moving the shim to the `public` tree so it finds its way to the `dist` folder where it can be referenced from the manifest. But then this file would also lay around there for normal browser builds...

I thought the current approach would be most simple and "good enough", but happy to refactor in case of objections!

Ah, and I extended the FastBoot tests, so now the actual liquid-fire components like `liquid-outlet`, `liquid-bind` and `liquid-if` are actually covered in those tests. These tests are now actually failing without the changes in `index.js`, uncovering the current issue. The test are still running with the older pre 1.0 `ember-cli-fastboot`, but I tested the changes also locally with the latest PR https://github.com/ember-fastboot/ember-cli-fastboot/pull/369.

Sorry again for the trouble!

cc @kratiahuja