### PR TITLE
Allow wait transition to pass then options

### DIFF
--- a/addon/transitions/wait.js
+++ b/addon/transitions/wait.js
@@ -1,9 +1,11 @@
 import Ember from 'ember';
 
-export default function(ms, opts={}) {
+export default function(ms, opts, ...rest) {
+  opts = opts !== undefined ? opts : {};
+
   return new Ember.RSVP.Promise(resolve => {
     setTimeout(() => {
-      resolve(this.lookup(opts.then || 'default').call(this));
+      resolve(this.lookup(opts.then || 'default').call(this, ...rest));
     }, ms);
   });
 }


### PR DESCRIPTION
Right now the `wait` transition doesn't allow for options to be passed to the delayed transition.

This PR allows for waited transition to get the required options.

Example transition:


```js
this.transition(
  this.fromRoute('index'),
  this.use('wait', 200, { then: 'slideLeft' }, { duration: 400 })
);
```

This PR is even more helpful when used with the `explode` transition:

```js
this.transition(
  this.fromRoute('index'),
  this.use('explode', {
    pickNew: '.bg',
    use: ['fade', { duration: 400 }]
  }, {
    pickNew: '.slider',
    use: ['wait', 400, { then: 'slideRight' }, { duration: 200 }
  }
);
```