### PR TITLE
Update getowner-polyfill version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-babel": "^6.1.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-version-checker": "^1.2.0",
-    "ember-getowner-polyfill": "^1.1.1",
+    "ember-getowner-polyfill": "^2.0.1",
     "ember-hash-helper-polyfill": "^0.1.2",
     "match-media": "^0.2.0",
     "velocity-animate": ">= 0.11.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,11 +2656,10 @@ ember-fastboot-addon-tests@^0.4.0:
     request "^2.74.0"
     rsvp "^3.3.1"
 
-ember-getowner-polyfill@^1.1.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.2.tgz#cdab739e89cc8f25af0f78735422df1a61193e92"
+ember-getowner-polyfill@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-2.0.1.tgz#9bfe2b4d527ed174e76fef2c8f30937d77cb66fb"
   dependencies:
-    ember-cli-babel "^5.1.6"
     ember-cli-version-checker "^1.2.0"
     ember-factory-for-polyfill "^1.1.0"
 


### PR DESCRIPTION
This update removes the deprecated import syntax that has already been
handled in this addon in a9fdbfec8d7dfb4139ab409519c0aa3152c601d7