### PR TITLE
satisfy new eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,12 @@ module.exports = {
     ecmaVersion: 2017,
     sourceType: 'module'
   },
-  extends: 'eslint:recommended',
   plugins: [
     'ember'
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:ember/recommended'
   ],
   env: {
     browser: true
@@ -18,5 +21,43 @@ module.exports = {
     'ember/new-module-imports': 'error',
     'ember/avoid-leaking-state-in-components': 'error',
     'ember/no-side-effects': 'error'
-  }
+  },
+  overrides: [
+    // node files
+    {
+      files: [
+        'index.js',
+        'testem.js',
+        'ember-cli-build.js',
+        'config/**/*.js',
+        'tests/dummy/config/**/*.js'
+      ],
+      excludedFiles: [
+        'app/**',
+        'addon/**',
+        'tests/dummy/app/**'
+      ],
+      parserOptions: {
+        sourceType: 'script',
+        ecmaVersion: 2015
+      },
+      env: {
+        browser: false,
+        node: true
+      },
+      plugins: ['node'],
+      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+        // add your custom rules and overrides for node files here
+      })
+    },
+
+    // test files
+    {
+      files: ['tests/**/*.js'],
+      excludedFiles: ['tests/dummy/**/*.js'],
+      env: {
+        embertest: true
+      }
+    }
+  ]
 };

--- a/config/deploy.js
+++ b/config/deploy.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 module.exports = function(deployTarget) {
   let ENV = {
     build: {},

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   useYarn: true,
   scenarios: [

--- a/config/environment.js
+++ b/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(/* environment, appConfig */) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 let VersionChecker = require('ember-cli-version-checker');

--- a/testem.js
+++ b/testem.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  env: {
-    embertest: true
-  }
-};

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 'use strict';
 
 module.exports = function(environment) {

--- a/tests/dummy/config/targets.js
+++ b/tests/dummy/config/targets.js
@@ -1,4 +1,3 @@
-/* eslint-env node */
 module.exports = {
   browsers: [
     'ie 9',


### PR DESCRIPTION
This PR applies the default eslint rules that come from the latest ember-cli. It's not ready to merge because there are failures:

```
$ yarn run lint:js
yarn run v1.3.2
$ eslint ./*.js addon addon-test-support app config lib server test-support tests

/Users/edward/hacking/liquid-fire/addon/components/liquid-child.js
  19:9  error  Use closure actions, unless you need bubbling  ember/closure-actions

/Users/edward/hacking/liquid-fire/addon/components/liquid-container.js
  45:24  error  Don't use .on() in components  ember/no-on-calls-in-components

/Users/edward/hacking/liquid-fire/config/deploy.js
  2:3  error  'let' declarations in non-strict mode are not supported yet on Node 4.5.0  node/no-unsupported-features

/Users/edward/hacking/liquid-fire/tests/dummy/app/controllers/helpers-documentation/liquid-if.js
  6:3  error  Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties  ember/avoid-leaking-state-in-ember-objects
  7:3  error  Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties  ember/avoid-leaking-state-in-ember-objects

/Users/edward/hacking/liquid-fire/tests/dummy/app/controllers/scenarios/hero.js
  17:3  error  Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties  ember/avoid-leaking-state-in-ember-objects

/Users/edward/hacking/liquid-fire/tests/dummy/app/controllers/scenarios/spacer.js
  4:3  error  Only string, number, symbol, boolean, null, undefined, and function are allowed as default properties  ember/avoid-leaking-state-in-ember-objects

/Users/edward/hacking/liquid-fire/tests/dummy/app/controllers/test-bind.js
  6:3  error  Call this._super(...arguments) in init hook  ember/require-super-in-init

✖ 8 problems (8 errors, 0 warnings)
```

Cleaning up these rule violations is a good new contributor issue.