### PR TITLE
Be more strict with our velocity version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-getowner-polyfill": "^2.0.1",
     "ember-hash-helper-polyfill": "^0.2.0",
     "match-media": "^0.2.0",
-    "velocity-animate": ">= 0.11.8"
+    "velocity-animate": "^1.5.1"
   },
   "devDependencies": {
     "bower": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7547,9 +7547,9 @@ vary@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.0.tgz#e1e5affbbd16ae768dd2674394b9ad3022653140"
 
-"velocity-animate@>= 0.11.8":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.4.0.tgz#b220a79cecfcdceeaf66c44e09ee9532bf5fcea5"
+velocity-animate@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.1.tgz#606837047bab8fbfb59a636d1d82ecc3f7bd71a6"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
Because there is a velocity 2.0 out that is not compatible at the moment.