### PR TITLE
Guards against notifying a destroyed container

### DIFF
--- a/addon/components/liquid-versions.js
+++ b/addon/components/liquid-versions.js
@@ -109,7 +109,7 @@ export default Component.extend({
 
   notifyContainer: function(method, versions) {
     let target = get(this, 'notify');
-    if (target) {
+    if (target && !target.get('isDestroying')) {
       target.send(method, versions);
     }
   },


### PR DESCRIPTION
When I upgraded Ember source to `3.3.0-beta.5`, all my acceptance tests started failing with an error about `.send() on a destroyed object`, similarly to emberjs/ember.js#16820

This was my quick fix to a green suite, which I post here for FYI purposes.