### PR TITLE
Fix ember-component.send-action deprecation introduced in ember 3.4

### DIFF
--- a/addon/components/liquid-child.js
+++ b/addon/components/liquid-child.js
@@ -1,5 +1,6 @@
 import { Promise as EmberPromise } from 'rsvp';
 import Component from '@ember/component';
+import { get } from '@ember/object';
 export default Component.extend({
   classNames: ['liquid-child'],
 
@@ -16,7 +17,11 @@ export default Component.extend({
     this._waitForAll().then(() => {
       if (!this.isDestroying) {
         this._waitingFor = null;
-        this.sendAction('liquidChildDidRender', this);
+
+        const didRenderAction = get(this, 'liquidChildDidRender');
+        if (typeof(didRenderAction) === 'function') {
+          didRenderAction(this);
+        }
       }
     });
   },

--- a/addon/templates/components/liquid-versions.hbs
+++ b/addon/templates/components/liquid-versions.hbs
@@ -1,6 +1,6 @@
 {{#each versions as |version| ~}}
   {{#if (lf-or renderWhenFalse version.value) ~}}
-    {{#liquid-child version=version liquidChildDidRender="childDidRender" class=class ~}}
+    {{#liquid-child version=version liquidChildDidRender=(action "childDidRender") class=class ~}}
       {{yield version.value ~}}
     {{/liquid-child}}
   {{/if}}


### PR DESCRIPTION
Fixes #618 

Not sure if extra work needs to be to keep backwards compat.