### PR TITLE
Fix `_super` in included hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,7 @@ module.exports = {
   },
 
   included: function(){
-    this._super.apply(this, arguments);
+    this._super.included.apply(this, arguments);
 
     // We cannot use ember-cli to import velocity as an AMD module here, because we always need the shim in FastBoot
     // to not break any module imports (as velocity/velocity.js has a FastBoot guard, so FastBoot does not see any


### PR DESCRIPTION
Otherwise it could lead to error like:

```
TypeError: this._super.apply is not a function
    at Class.included (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/liquid-fire/index.js:109:17)
    at EmberApp.<anonymous> (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/broccoli/ember-app.js:433:15)
    at Array.filter (native)
    at EmberApp._notifyAddonIncluded (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/broccoli/ember-app.js:428:45)
    at new EmberApp (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/broccoli/ember-app.js:109:8)
    at module.exports (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/ember-cli-build.js:14:13)
    at Class.setupBroccoliBuilder (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/builder.js:55:19)
    at Class.init (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/models/builder.js:89:10)
    at new Class (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/node_modules/core-object/core-object.js:18:12)
    at Class.run (/home/ctjhoa/workspace/Negotiation-App/src/main/webapp/static/jscripts/app-cli/node_modules/ember-cli/lib/tasks/serve.js:15:19)
```