### PR TITLE
Hopefully Easy jQuery Fixes

### DIFF
--- a/addon/components/liquid-container.js
+++ b/addon/components/liquid-container.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import Growable from "liquid-fire/growable";
 import { measure } from "./liquid-measured";
 import layout from "liquid-fire/templates/components/liquid-container";
+import $ from 'jquery';
 
 export default Component.extend(Growable, {
   layout,
@@ -54,7 +55,7 @@ export default Component.extend(Growable, {
       }
 
       // Remember our own size before anything changes
-      let elt = this.$();
+      let elt = $(this.element);
       this._cachedSize = measure(elt);
 
       // And make any children absolutely positioned with fixed sizes.
@@ -65,14 +66,15 @@ export default Component.extend(Growable, {
     },
 
     afterChildInsertion(versions) {
-      let elt = this.$();
+      let elt = $(this.element);
       let enableGrowth = this.get('enableGrowth') !== false;
 
       // Measure children
       let sizes = [];
       for (let i = 0; i < versions.length; i++) {
         if (versions[i].view) {
-          sizes[i] = measure(versions[i].view.$());
+          let childElt = $(versions[i].view.element);
+          sizes[i] = measure(childElt);
         }
       }
 
@@ -119,7 +121,7 @@ function goAbsolute(version, size) {
   if (!version.view) {
     return;
   }
-  let elt = version.view.$();
+  let elt = $(version.view.element);
   let pos = elt.position();
   if (!size) {
     size = measure(elt);
@@ -135,6 +137,7 @@ function goAbsolute(version, size) {
 
 function goStatic(version) {
   if (version.view && !version.view.isDestroyed) {
-    version.view.$().css({width: '', height: '', position: ''});
+    let elt = $(version.view.element);
+    elt.css({width: '', height: '', position: ''});
   }
 }

--- a/addon/components/liquid-measured.js
+++ b/addon/components/liquid-measured.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import MutationObserver from "liquid-fire/mutation-observer";
 import layout from "liquid-fire/templates/components/liquid-measured";
+import $ from 'jquery';
 
 export default Component.extend({
   layout,
@@ -16,9 +17,7 @@ export default Component.extend({
     let self = this;
 
     // This prevents margin collapse
-    this.$().css({
-      overflow: 'auto'
-    });
+    this.element.style.overflow = 'auto';
 
     this.didMutate();
 
@@ -29,7 +28,9 @@ export default Component.extend({
       childList: true,
       characterData: true
     });
-    this.$().bind('webkitTransitionEnd', function() { self.didMutate(); });
+
+    let elt = $(this.element);
+    elt.bind('webkitTransitionEnd', function() { self.didMutate(); });
     // Chrome Memory Leak: https://bugs.webkit.org/show_bug.cgi?id=93661
     window.addEventListener('unload', this._destroyOnUnload);
   },
@@ -57,8 +58,8 @@ export default Component.extend({
   },
 
   _didMutate() {
-    let elt = this.$();
-    if (!elt || !elt[0]) { return; }
+    if (!this.element) { return; }
+    let elt = $(this.element);
     this.set('measurements', measure(elt));
   },
 

--- a/addon/components/liquid-spacer.js
+++ b/addon/components/liquid-spacer.js
@@ -3,16 +3,19 @@ import Component from '@ember/component';
 import { measure } from "./liquid-measured";
 import Growable from "liquid-fire/growable";
 import layout from "liquid-fire/templates/components/liquid-spacer";
+import $ from 'jquery';
 
 export default Component.extend(Growable, {
   layout,
   enabled: true,
 
   didInsertElement() {
-    let child = this.$('> div');
+    let elt = $(this.element);
+    let child = elt.find('> div');
     let measurements = this.myMeasurements(measure(child));
-    let elt = this.$();
-    elt.css('overflow', 'hidden');
+
+    this.element.style.overflow = 'hidden';
+
     if (this.get('growWidth')) {
       elt.outerWidth(measurements.width);
     }
@@ -23,17 +26,17 @@ export default Component.extend(Growable, {
 
   sizeChange: observer('measurements', function() {
     if (!this.get('enabled')) { return; }
-    let elt = this.$();
-    if (!elt || !elt[0]) { return; }
+    if (!this.element) { return; }
     let want = this.myMeasurements(this.get('measurements'));
-    let have = measure(this.$());
+    let elt = $(this.element);
+    let have = measure(elt);
     this.animateGrowth(elt, have, want);
   }),
 
   // given our child's outerWidth & outerHeight, figure out what our
   // outerWidth & outerHeight should be.
   myMeasurements(childMeasurements) {
-    let elt = this.$();
+    let elt = $(this.element);
     return {
       width: childMeasurements.width + sumCSS(elt, padding('width')) + sumCSS(elt, border('width')),
       height: childMeasurements.height + sumCSS(elt, padding('height')) + sumCSS(elt, border('height'))

--- a/addon/running-transition.js
+++ b/addon/running-transition.js
@@ -1,4 +1,5 @@
 import { capitalize } from '@ember/string';
+import $ from 'jquery';
 
 export default class RunningTransition {
   constructor(transitionMap, versions, animation) {
@@ -62,9 +63,15 @@ function publicAnimationContext(rt, versions) {
 }
 
 function addPublicVersion(context, prefix, version) {
+  let elt = null;
+
+  if (version.view) {
+    elt = $(version.view.element);
+  }
+
   let props = {
     view: version.view,
-    element: version.view ? version.view.$() : null,
+    element: elt,
     value: version.value
   };
   for (let key in props) {


### PR DESCRIPTION
Instead of accessing a Component's `this.$()` property, which is
deprecated in modern Ember, we manually wrap `this.element`. I've taken
care of a cases of jQuery usage that were easy to fix, but most have
been left alone to mitigate the chances of a regression.