### PR TITLE
Remove ember-copy

### DIFF
--- a/addon/animate.js
+++ b/addon/animate.js
@@ -1,7 +1,7 @@
 /* jshint newcap: false */
-import { copy } from 'ember-copy';
 import Promise from "./promise";
 import Velocity from "velocity";
+import { assign } from '@ember/polyfills';
 
 // Make sure Velocity always has promise support by injecting our own
 // RSVP-based implementation if it doesn't already have one.
@@ -28,7 +28,7 @@ export function animate(elt, props, opts, label) {
   if (!opts) {
     opts = {};
   } else {
-    opts = copy(opts);
+    opts = assign({}, opts);
   }
 
   // By default, we ask velocity to clear the element's `display`

--- a/addon/transitions/explode.js
+++ b/addon/transitions/explode.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 import { isArray, A } from '@ember/array';
 import { guidFor } from '@ember/object/internals';
-import { copy } from 'ember-copy';
+import { assign } from '@ember/polyfills';
 import { Promise } from "liquid-fire";
 
 // Explode is not, by itself, an animation. It exists to pull apart
@@ -33,7 +33,7 @@ export default function explode(...pieces) {
 }
 
 function explodePiece(context, piece, seen) {
-  let childContext = copy(context);
+  let childContext = assign({}, context);
   let selectors = [piece.pickOld || piece.pick, piece.pickNew || piece.pick];
   let cleanupOld, cleanupNew;
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "ember-cli-babel": "^7.7.3",
     "ember-cli-htmlbars": "^3.0.1",
     "ember-cli-version-checker": "^3.1.3",
-    "ember-copy": "^1.0.0",
     "match-media": "^0.2.0",
     "velocity-animate": "^1.5.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4217,12 +4217,6 @@ ember-code-snippet@^2.4.0:
     es6-promise "^1.0.0"
     glob "^7.1.3"
 
-ember-copy@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
-  dependencies:
-    ember-cli-babel "^6.6.0"
-
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
This addon was relying upon an old version of liquid-fire. This was
causing some wacky problems wherein shipped code was using old versions
of liquid-fire.