### PR TITLE
[FIX] deduplicate `explode` cloned dom element `id` attributes

### DIFF
--- a/addon/transitions/explode.js
+++ b/addon/transitions/explode.js
@@ -2,11 +2,29 @@ import $ from 'jquery';
 import { isArray, A } from '@ember/array';
 import { guidFor } from '@ember/object/internals';
 import { assign } from '@ember/polyfills';
-import { Promise } from "liquid-fire";
+import { Promise } from 'liquid-fire';
 
 // Explode is not, by itself, an animation. It exists to pull apart
 // other elements so that each of the pieces can be targeted by
 // animations.
+
+let deduplicateChildElementIds = (parentElem) => {
+  if (!parentElem) {
+    return;
+  }
+
+  let parentEl = parentElem[0];
+  if (parentEl.id) {
+    parentEl.setAttribute('id', `${guidFor(parentEl)}-${parentEl.id}`);
+  }
+
+  let childrenWithUniqueIds = parentEl.querySelectorAll('[id]');
+  if (childrenWithUniqueIds.length) {
+    for (let el of childrenWithUniqueIds) {
+      el.setAttribute('id', `${guidFor(el)}-${el.id}`);
+    }
+  }
+};
 
 export default function explode(...pieces) {
   let seenElements = {};
@@ -69,6 +87,8 @@ function _explodePart(context, field, childContext, selector, seen) {
       width = child.outerWidth();
       height = child.outerHeight();
       newChild = child.clone();
+
+      deduplicateChildElementIds(newChild);
 
       // Hide the original element
       child.css({visibility: 'hidden'});

--- a/tests/integration/transitions/explode-test.js
+++ b/tests/integration/transitions/explode-test.js
@@ -495,6 +495,39 @@ module('Integration: explode transition', function(hooks) {
       assert.ok(didTransition, 'didTransition');
     });
 
+    test("deduplicate element ids from cloned explode DOM", async function(assert) {
+      // SEE: https://github.com/ember-animation/liquid-fire/issues/643
+      assert.expect(2);
+      tmap.map(function() {
+        this.transition(
+          this.hasClass('explode-transition-test'),
+          this.use('explode', {
+            pick: 'h1',
+            use: function() {
+              assert.equal(document.querySelectorAll('#unique-parent-id').length, 1, 'cloned top level DOM element does not have duplicated id attribute');
+              assert.equal(document.querySelectorAll('#unique-child-id').length, 1, 'any cloned child DOM does not have duplicate id attributes');
+              return resolve();
+            }
+          })
+        );
+      });
+      await render(hbs`
+        {{#liquid-if showTitleOne class="explode-transition-test"}}
+          <div>
+            <h1>Title 1</h1>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odio error vitae consequuntur quasi, pariatur odit ea itaque libero repudiandae dolor nam minus assumenda, blanditiis natus sit unde illo quibusdam quos.</p>
+          </div>
+        {{else}}
+        <div>
+            <h1 id="unique-parent-id">Title 2 <input id="unique-child-id" type="text"></h1>
+            <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Odio error vitae consequuntur quasi, pariatur odit ea itaque libero repudiandae dolor nam minus assumenda, blanditiis natus sit unde illo quibusdam quos.</p>
+          </div>
+        {{/liquid-if}}
+      `);
+      this.set('showTitleOne', true);
+      return tmap.waitUntilIdle();
+    });
+
   });
 
   function stylesheet() {


### PR DESCRIPTION
FIX: https://github.com/ember-animation/liquid-fire/issues/643

Adds failing test + the actual fix