### PR TITLE
Fix container size calculation

### DIFF
--- a/addon/components/liquid-container.js
+++ b/addon/components/liquid-container.js
@@ -80,7 +80,10 @@ export default Component.extend(Growable, {
 
       // Measure ourself again to see how big the new children make
       // us.
-      let want = measure(elt);
+      let want = {
+        width: Math.max(...sizes.map(size => size.width)),
+        height: Math.max(...sizes.map(size => size.height)),
+      };
       let have = this._cachedSize || want;
 
       // Make ourself absolute


### PR DESCRIPTION
The container size is calculated based on its current width and height, but the current child is set to `position: absolute`, before this calculation making it shorter that it should