### PR TITLE
Fix / DEPRECATION: `hasBlock` is deprecated. Use `has-block` instead.

### DIFF
--- a/addon/templates/components/liquid-bind.hbs
+++ b/addon/templates/components/liquid-bind.hbs
@@ -3,7 +3,7 @@
                      matchContext=forwardMatchContext
                      versionEquality=versionEquality
                      renderWhenFalse=true class=class as |version| ~}}
-    {{~#if hasBlock}}
+    {{~#if has-block}}
       {{~yield version ~}}
     {{else}}
       {{~version ~}}
@@ -26,7 +26,7 @@
                        versionEquality=versionEquality
                        renderWhenFalse=true as |version| ~}}
 
-      {{~#if hasBlock}}
+      {{~#if has-block}}
         {{~yield version ~}}
       {{else}}
         {{~version ~}}

--- a/addon/templates/components/liquid-if.hbs
+++ b/addon/templates/components/liquid-if.hbs
@@ -10,7 +10,7 @@
   }}
 
   {{#liquid-versions value=(if inverted (if predicate false true) (if predicate true false)) matchContext=(hash helperName=helperName)
-                       use=use rules=rules renderWhenFalse=(hasBlock "inverse") class=class as |valueVersion|}}
+                       use=use rules=rules renderWhenFalse=(has-block "inverse") class=class as |valueVersion|}}
     {{#if valueVersion}}
       {{yield}}
     {{else}}
@@ -29,7 +29,7 @@
       enableGrowth=enableGrowth
       as |container|}}
     {{#liquid-versions value=(if inverted (if predicate false true) (if predicate true false)) notify=container matchContext=(hash helperName=helperName)
-    use=use rules=rules renderWhenFalse=(hasBlock "inverse") as |valueVersion|}}
+    use=use rules=rules renderWhenFalse=(has-block "inverse") as |valueVersion|}}
       {{#if valueVersion}}
         {{yield}}
       {{else}}


### PR DESCRIPTION
This PR fixes https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params