### PR TITLE
Remove Ember global usage

### DIFF
--- a/addon/ember-internals.js
+++ b/addon/ember-internals.js
@@ -1,6 +1,5 @@
 import { get } from '@ember/object';
-import Ember from 'ember';
-const { getViewBounds } = Ember.ViewUtils;
+import { getViewBounds } from '@ember/-internals/views';
 
 // Traverses down to the child routeInfo with the given name.
 export function childRoute(routeInfo, outletName) {

--- a/addon/transition-map.js
+++ b/addon/transition-map.js
@@ -6,7 +6,6 @@ import Service from '@ember/service';
 import { DEBUG } from '@glimmer/env';
 import RunningTransition from "./running-transition";
 import DSL from "./dsl";
-import Ember from "ember";
 import Action from "./action";
 import Constraints from "./constraints";
 
@@ -17,6 +16,7 @@ let TransitionMap = Service.extend({
     this.activeCount = 0;
     this.constraints = new Constraints();
     let owner = getOwner(this);
+    this.isTest = owner.resolveRegistration('config:environment').environment === 'test'
     let config;
     if (owner.factoryFor) {
       let maybeConfig = owner.factoryFor('transitions:main');
@@ -127,7 +127,7 @@ if (DEBUG) {
     init() {
       this._super(...arguments);
 
-      if (Ember.testing) {
+      if (this.isTest) {
         this._waiter = () => {
           return this.runningTransitions() === 0;
         };


### PR DESCRIPTION
I'm not sure if this does what I intend it to do, but hopefully it removes Ember globals for embroider support