### PR TITLE
fix replacer

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,14 +38,12 @@ module.exports = {
     }
   },
 
-  treeForAddon(_tree) {
+  treeForAddon(tree) {
     let checker = new VersionChecker(this.project);
     let dep = checker.for('ember-source');
 
-    let tree;
-
     if (dep.gte('4.0.0-alpha.0', { includePrerelease: true })) {
-      tree = replace('addon', {
+      tree = replace(tree, {
         files: ['templates/components/liquid-outlet.hbs'],
         pattern: {
           match: /{{outlet this.outletName}}/g,
@@ -54,7 +52,7 @@ module.exports = {
       });
     }
 
-    return this._super.treeForAddon.call(this, tree || _tree);
+    return this._super.treeForAddon.call(this, tree);
   },
 
   treeForVendor(tree) {


### PR DESCRIPTION
This only works when you run it inside the dummy app. In any real app it fails, because it will get the `addon` directory relative to the current working directory. It's especially confusing inside another addon, which has its own `addon` directory that will get incorporated into liquid-fire, replacing its own.

This is the source of errors like

> Could not find module `liquid-fire/velocity-ext` imported from `dummy/initializers/liquid-fire`