### PR TITLE
Remove ember-source as a peer dependency

### DIFF
--- a/liquid-fire/package.json
+++ b/liquid-fire/package.json
@@ -101,7 +101,6 @@
     "extends": "../package.json"
   },
   "peerDependencies": {
-    "ember-source": ">= 3.28.0",
     "velocity-animate": "^1.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,9 +219,6 @@ importers:
       ember-modifier:
         specifier: ^4.2.0
         version: 4.2.0(@babel/core@7.25.2)(ember-source@4.12.4)
-      ember-source:
-        specifier: '>= 3.28.0'
-        version: 4.12.4(@babel/core@7.25.2)(@glimmer/component@1.1.2)(webpack@5.93.0)
       velocity-animate:
         specifier: ^1.5.2
         version: 1.5.2


### PR DESCRIPTION
ember-source: removed because the embroider / auto-import know what we intend - it's not bad to have if someone manages their dep graph correctly, which is easier with pnpm, but not everyone gets it right, and folks have a hard time tracking down errors

ref https://github.com/ember-cli/ember-addon-blueprint/pull/35